### PR TITLE
Fixed STDCXX_SYNC build.

### DIFF
--- a/xtransmit/receive.cpp
+++ b/xtransmit/receive.cpp
@@ -21,8 +21,6 @@
 #include "apputil.hpp"
 #include "uriparser.hpp"
 
-#include "handshake.h"
-
 using namespace std;
 using namespace xtransmit;
 using namespace xtransmit::receive;

--- a/xtransmit/xtransmit-app.cpp
+++ b/xtransmit/xtransmit-app.cpp
@@ -11,11 +11,9 @@
 #include "spdlog/spdlog.h"
 
 // SRT libraries
-#include "udt.h"	// srt_logger_config
 #include "apputil.hpp"
 #include "uriparser.hpp"
 #include "srt_node.hpp"
-#include "logging.h"
 #include "logsupport.hpp"
 #include "verbose.hpp"
 


### PR DESCRIPTION
The 'forward' subcommand was using logger that somehow was including sync.h without a proper macro definition.
Replaced SRT logger in forwarder with SPDLOG.