### PR TITLE
Throw exception on invalid URI query

### DIFF
--- a/xtransmit/generate.cpp
+++ b/xtransmit/generate.cpp
@@ -118,7 +118,7 @@ void xtransmit::generate::run(const string& dst_url, const config& cfg, const at
 	}
 	catch (const socket::exception& e)
 	{
-		spdlog::warn(LOG_SC_GENERATE "{}", e.what());
+		spdlog::error(LOG_SC_GENERATE "{}", e.what());
 		return;
 	}
 }

--- a/xtransmit/receive.cpp
+++ b/xtransmit/receive.cpp
@@ -176,7 +176,7 @@ void xtransmit::receive::run(const string &src_url, const config &cfg, const ato
 	}
 	catch (const socket::exception & e)
 	{
-		cerr << e.what() << endl;
+		spdlog::error(LOG_SC_RECEIVE "{}", e.what());
 	}
 }
 

--- a/xtransmit/route.cpp
+++ b/xtransmit/route.cpp
@@ -120,7 +120,7 @@ void xtransmit::route::run(const string& src_url, const string& dst_url,
 	}
 	catch (const socket::exception & e)
 	{
-		cerr << e.what() << endl;
+		spdlog::error(LOG_SC_ROUTE "{}", e.what());
 	}
 }
 

--- a/xtransmit/srt_socket.hpp
+++ b/xtransmit/srt_socket.hpp
@@ -15,17 +15,17 @@
 #include "udt.h"
 #include "uriparser.hpp"
 
-
-namespace xtransmit {
-namespace socket {
-
+namespace xtransmit
+{
+namespace socket
+{
 
 class srt
 	: public std::enable_shared_from_this<srt>
 	, public isocket
 {
-	using string		= std::string;
-	using shared_srt	= std::shared_ptr<srt>;
+	using string     = std::string;
+	using shared_srt = std::shared_ptr<srt>;
 
 public:
 	explicit srt(const UriParser& src_uri);
@@ -34,33 +34,38 @@ public:
 
 	virtual ~srt();
 
-
 public:
 	std::future<shared_srt> async_connect() noexcept(false);
-	std::future<shared_srt> async_accept()  noexcept(false);
+	std::future<shared_srt> async_accept() noexcept(false);
 
-
-	shared_srt				connect();
-	shared_srt				accept();
+	shared_srt connect();
+	shared_srt accept();
 
 	/**
 	 * Start listening on the incomming connection requests.
 	 *
-	 * May throw a socket_exception.
+	 * May throw a socket::exception.
 	 */
-	void					listen() noexcept(false);
+	void listen() noexcept(false);
+
+	/// Verifies URI options provided are valid.
+	///
+	/// @param [in] options  a map of options key-value pairs to validate
+	/// @throw socket::exception on failure
+	///
+	static void assert_options_valid(const std::map<string, string>& options);
 
 private:
-	void configure(const std::map<string, string> &options);
+	void configure(const std::map<string, string>& options);
 
-	void check_options_exist() const;
+	void assert_options_valid() const;
 	int  configure_pre(SRTSOCKET sock);
 	int  configure_post(SRTSOCKET sock);
 	void handle_hosts();
 
 public:
-	std::future<shared_srt>  async_read(std::vector<char> &buffer);
-	void async_write();
+	std::future<shared_srt> async_read(std::vector<char>& buffer);
+	void                    async_write();
 
 	/**
 	 * @returns The number of bytes received.
@@ -68,11 +73,11 @@ public:
 	 * @throws socket_exception Thrown on failure.
 	 */
 	size_t read(const mutable_buffer& buffer, int timeout_ms = -1) final;
-	int   write(const const_buffer&   buffer, int timeout_ms = -1) final;
+	int    write(const const_buffer& buffer, int timeout_ms = -1) final;
 
 	enum connection_mode
 	{
-		FAILURE    =-1,
+		FAILURE    = -1,
 		LISTENER   = 0,
 		CALLER     = 1,
 		RENDEZVOUS = 2
@@ -83,28 +88,27 @@ public:
 	bool is_caller() const final { return m_mode == CALLER; }
 
 public:
-	int id() const final { return m_bind_socket; }
-	int statistics(SRT_TRACEBSTATS &stats, bool instant = true);
-	bool supports_statistics() const final { return true; }
-	const std::string statistics_csv(bool print_header) final;
+	int                      id() const final { return m_bind_socket; }
+	int                      statistics(SRT_TRACEBSTATS& stats, bool instant = true);
+	bool                     supports_statistics() const final { return true; }
+	const std::string        statistics_csv(bool print_header) final;
 	static const std::string stats_to_csv(int socketid, const SRT_TRACEBSTATS& stats, bool print_header);
 
 private:
 	void raise_exception(const string&& place) const;
-	void raise_exception(const string &&place, const string&& reason) const;
+	void raise_exception(const string&& place, const string&& reason) const;
 
 private:
-	int m_bind_socket	= SRT_INVALID_SOCK;
-	int m_epoll_connect	= -1;
-	int m_epoll_io		= -1;
+	int m_bind_socket   = SRT_INVALID_SOCK;
+	int m_epoll_connect = -1;
+	int m_epoll_io      = -1;
 
-	connection_mode m_mode = FAILURE;
-	bool m_blocking_mode = false;
-	string m_host;
-	int m_port = -1;
+	connection_mode          m_mode          = FAILURE;
+	bool                     m_blocking_mode = false;
+	string                   m_host;
+	int                      m_port = -1;
 	std::map<string, string> m_options; // All other options, as provided in the URI
 };
 
 } // namespace socket
 } // namespace xtransmit
-


### PR DESCRIPTION
Addresses #25.

- [x] `generate` and `receive` subcommands report an error.

Unsolved item:

`route "srt://:4200?modest=caller" srt://4201 -v` tries to connect destination first, then check the source and report an error.