### PR TITLE
Multiple client connections (receive, generate)

### DIFF
--- a/xtransmit/generate.cpp
+++ b/xtransmit/generate.cpp
@@ -97,7 +97,7 @@ void xtransmit::generate::run(const std::vector<std::string>& dst_urls, const co
 {
 	using namespace std::placeholders;
 	processing_fn_t process_fn = std::bind(run_pipe, _1, cfg, _2);
-	common_run(dst_urls, cfg, cfg.reconnect, cfg.close_listener, force_break, process_fn);
+	common_run(dst_urls, cfg, cfg, force_break, process_fn);
 }
 
 CLI::App* xtransmit::generate::add_subcommand(CLI::App& app, config& cfg, std::vector<std::string>& dst_urls)
@@ -119,6 +119,7 @@ CLI::App* xtransmit::generate::add_subcommand(CLI::App& app, config& cfg, std::v
 	sc_generate->add_option("--statsfreq", cfg.stats_freq_ms, fmt::format("Output stats report frequency, ms (default {})", cfg.stats_freq_ms))
 		->transform(CLI::AsNumberWithUnit(to_ms, CLI::AsNumberWithUnit::CASE_SENSITIVE));
 	sc_generate->add_flag("--twoway", cfg.two_way, "Both send and receive data");
+	sc_generate->add_option("--clients", cfg.client_conns, "Number of client connections to initiate or accept");
 	sc_generate->add_flag("--reconnect,!--no-reconnect", cfg.reconnect, "Reconnect automatically");
 	sc_generate->add_flag("--close-listener,!--no-close-listener", cfg.close_listener, "Close listener once connection is established");
 	sc_generate->add_flag("--enable-metrics", cfg.enable_metrics, "Enable embeding metrics: latency, loss, reordering, jitter, etc.");

--- a/xtransmit/generate.cpp
+++ b/xtransmit/generate.cpp
@@ -122,13 +122,11 @@ CLI::App* xtransmit::generate::add_subcommand(CLI::App& app, config& cfg, std::v
 	sc_generate->add_option("--statsfreq", cfg.stats_freq_ms, fmt::format("Output stats report frequency, ms (default {})", cfg.stats_freq_ms))
 		->transform(CLI::AsNumberWithUnit(to_ms, CLI::AsNumberWithUnit::CASE_SENSITIVE));
 	sc_generate->add_flag("--twoway", cfg.two_way, "Both send and receive data");
-	sc_generate->add_option("--maxconns", cfg.max_conns, "Maximum Number of connections to initiate or accept");
-	sc_generate->add_option("--concurrent-streams", cfg.concurrent_streams, "Maximum Number of concurrect generating streams");
-	sc_generate->add_flag("--reconnect,!--no-reconnect", cfg.reconnect, "Reconnect automatically");
-	sc_generate->add_flag("--close-listener,!--no-close-listener", cfg.close_listener, "Close listener once connection is established");
 	sc_generate->add_flag("--enable-metrics", cfg.enable_metrics, "Enable embeding metrics: latency, loss, reordering, jitter, etc.");
 	sc_generate->add_option("--playback-csv", cfg.playback_csv, "Input CSV file with timestamp of every packet");
 	sc_generate->add_flag("--spin-wait", cfg.spin_wait, "Use CPU-expensive spin waiting for better sending accuracy");
+	
+	apply_cli_opts(*sc_generate, cfg);
 
 	return sc_generate;
 }

--- a/xtransmit/generate.hpp
+++ b/xtransmit/generate.hpp
@@ -13,15 +13,15 @@ namespace xtransmit
 namespace generate
 {
 
-struct config : public stats_config
+struct config
+	: public stats_config
+	, public conn_config
 {
 	int         sendrate       = 0;
 	int         num_messages   = -1;
 	int         duration       = 0;
 	int         message_size   = 1316; ////8 * 1024 * 1024;
 	bool        two_way        = false;
-	bool        reconnect      = false;
-	bool        close_listener = false;
 	bool        enable_metrics = false;
 	bool        spin_wait      = false;
 	std::string playback_csv;

--- a/xtransmit/metrics.cpp
+++ b/xtransmit/metrics.cpp
@@ -153,7 +153,7 @@ bool validate_packet_checksum(const const_buffer& payload)
 
 std:: string validator::stats()
 {
-	std::lock_guard lock(m_mtx);
+	std::lock_guard<std::mutex> lock(m_mtx);
 	std::stringstream ss;
 
 	auto latency_str = [](long long val, long long na_val) -> string {
@@ -212,7 +212,7 @@ string validator::stats_csv()
 {
 	stringstream ss;
 
-	std::lock_guard lock(m_mtx);
+	std::lock_guard<std::mutex> lock(m_mtx);
 #ifdef HAS_PUT_TIME
 	ss << print_timestamp_now() << ',';
 #endif

--- a/xtransmit/metrics.hpp
+++ b/xtransmit/metrics.hpp
@@ -73,7 +73,7 @@ namespace metrics
 
 		inline void validate_packet(const const_buffer& payload)
 		{
-			std::lock_guard lock(m_mtx);
+			std::lock_guard<std::mutex> lock(m_mtx);
 			const auto sys_time_now = system_clock::now();
 			const auto std_time_now = steady_clock::now();
 			

--- a/xtransmit/metrics.hpp
+++ b/xtransmit/metrics.hpp
@@ -69,11 +69,11 @@ namespace metrics
 	class validator
 	{
 	public:
-		validator() {}
+		validator(int id) : m_id(id) {}
 
-	public:
 		inline void validate_packet(const const_buffer& payload)
 		{
+			std::lock_guard lock(m_mtx);
 			const auto sys_time_now = system_clock::now();
 			const auto std_time_now = steady_clock::now();
 			
@@ -99,14 +99,17 @@ namespace metrics
 		}
 
 		std::string stats();
-		std::string stats_csv(bool only_header = false);
+		std::string stats_csv();
+		static std::string stats_csv_header();
 
 	private:
+		const int m_id;
 		latency m_latency;
 		jitter m_jitter;
 		delay_factor m_delay_factor;
 		reorder m_reorder;
 		integrity m_integrity;
+		mutable std::mutex m_mtx;
 	};
 
 

--- a/xtransmit/metrics_writer.cpp
+++ b/xtransmit/metrics_writer.cpp
@@ -1,0 +1,156 @@
+#include <thread>
+#include "metrics_writer.hpp"
+
+// submodules
+#include "spdlog/spdlog.h"
+
+using namespace std;
+using namespace std::chrono;
+
+namespace xtransmit
+{
+namespace metrics
+{
+
+metrics_writer::metrics_writer(const std::string& filename, const std::chrono::milliseconds& interval)
+	: m_interval(interval)
+{
+	if (!filename.empty())
+	{
+		m_file.open(filename, ios::out);
+		if (!m_file)
+		{
+			const auto msg = fmt::format("[METRICS] Failed to open file for output. Path: {0}.", filename);
+			spdlog::critical(msg);
+			throw runtime_error(msg);
+		}
+		m_file << validator::stats_csv_header() << flush;
+	}
+}
+
+metrics_writer::~metrics_writer() { stop(); }
+
+void metrics_writer::add_validator(shared_validator v, SOCKET id)
+{
+	if (!v)
+	{
+		spdlog::error("[METRICS] No validator supplied.");
+		return;
+	}
+
+	m_lock.lock();
+	m_validators.emplace(make_pair(id, std::move(v)));
+	m_lock.unlock();
+
+	spdlog::trace("[METRICS] Added validator {}.", id);
+
+	if (m_metrics_future.valid())
+		return;
+
+	m_stop_token     = false;
+	m_metrics_future = launch();
+}
+
+void metrics_writer::remove_validator(SOCKET id)
+{
+	m_lock.lock();
+	const size_t n = m_validators.erase(id);
+	m_lock.unlock();
+
+	if (n == 1)
+	{
+		spdlog::trace("[METRICS] Removed validator {}.", id);
+	}
+	else
+	{
+		spdlog::trace("[METRICS] Removing validator {}: not found, num removed: {}.", id, n);
+	}
+}
+
+void metrics_writer::clear()
+{
+	std::lock_guard l(m_lock);
+	m_validators.clear();
+}
+
+void metrics_writer::stop()
+{
+	m_stop_token = true;
+	if (m_metrics_future.valid())
+		m_metrics_future.wait();
+}
+
+future<void> metrics_writer::launch()
+{
+	auto print_metrics = [](map<SOCKET, shared_validator>& validators, ofstream& fout, mutex& stats_lock)
+	{
+		const bool         print_to_file = fout.is_open();
+		scoped_lock<mutex> lock(stats_lock);
+
+		for (auto& it : validators)
+		{
+			if (!it.second)
+			{
+				// Skip empty (will be erased in a separate loop below).
+				continue;
+			}
+
+			auto* v = it.second.get();
+			if (v == nullptr)
+			{
+				spdlog::warn("[METRICS] Removing validator {}. Reason: nullptr.", it.first);
+				it.second.reset();
+				continue;
+			}
+
+			if (print_to_file)
+				fout << v->stats_csv() << flush;
+			else
+				spdlog::info("[METRICS] @{}: {}", it.first, v->stats());
+		}
+
+		auto delete_empty = [&validators]()
+		{
+			auto it = find_if(validators.begin(),
+							  validators.end(),
+							  [](pair<int, shared_validator> const& p)
+							  {
+								  return !p.second; // true if empty
+							  });
+			if (it == validators.end())
+				return false;
+
+			validators.erase(it);
+			return true;
+		};
+
+		// Check if there are empty sockets to delete.
+		// Cannot do it in the above for loop because this modifies the container.
+		while (delete_empty())
+		{
+		}
+
+		return;
+	};
+
+	auto metrics_func = [&print_metrics](map<SOCKET, shared_validator>& validators,
+										 ofstream&                   out,
+										 const milliseconds          interval,
+										 mutex&                      stats_lock,
+										 const atomic_bool&          stop_stats)
+	{
+		while (!stop_stats)
+		{
+			print_metrics(validators, out, stats_lock);
+
+			// No lock on stats_lock while sleeping
+			this_thread::sleep_for(interval);
+		}
+	};
+
+	return async(
+		::launch::async, metrics_func, ref(m_validators), ref(m_file), m_interval, ref(m_lock), ref(m_stop_token));
+}
+
+} // namespace metrics
+} // namespace xtransmit

--- a/xtransmit/metrics_writer.cpp
+++ b/xtransmit/metrics_writer.cpp
@@ -1,4 +1,5 @@
 #include <thread>
+#include <mutex>
 #include "metrics_writer.hpp"
 
 // submodules
@@ -69,7 +70,7 @@ void metrics_writer::remove_validator(SOCKET id)
 
 void metrics_writer::clear()
 {
-	std::lock_guard l(m_lock);
+	lock_guard<mutex> l(m_lock);
 	m_validators.clear();
 }
 
@@ -85,7 +86,7 @@ future<void> metrics_writer::launch()
 	auto print_metrics = [](map<SOCKET, shared_validator>& validators, ofstream& fout, mutex& stats_lock)
 	{
 		const bool         print_to_file = fout.is_open();
-		scoped_lock<mutex> lock(stats_lock);
+		lock_guard<mutex> lock(stats_lock);
 
 		for (auto& it : validators)
 		{

--- a/xtransmit/metrics_writer.hpp
+++ b/xtransmit/metrics_writer.hpp
@@ -1,0 +1,47 @@
+#pragma once
+#include <atomic>
+#include <chrono>
+#include <future>
+#include <fstream>
+#include <mutex>
+#include <string>
+#include <vector>
+#include <map>
+
+#include "metrics.hpp"
+#include "socket.hpp"
+
+
+namespace xtransmit
+{
+namespace metrics
+{
+
+class metrics_writer
+{
+public:
+	metrics_writer(const std::string& filename, const std::chrono::milliseconds& interval);
+	~metrics_writer();
+
+public:
+	using shared_sock = std::shared_ptr<socket::isocket>;
+	using shared_validator = std::shared_ptr<validator>;
+	void add_validator(shared_validator v, SOCKET id);
+	void remove_validator(SOCKET id);
+	void clear();
+	void stop();
+
+private:
+	std::future<void> launch();
+
+	std::atomic<bool> m_stop_token;
+	std::ofstream m_file;
+	std::map<SOCKET, shared_validator> m_validators;
+	std::future<void> m_metrics_future;
+	const std::chrono::milliseconds m_interval;
+	std::mutex m_lock;
+};
+
+} // namespace socket
+} // namespace xtransmit
+

--- a/xtransmit/misc.cpp
+++ b/xtransmit/misc.cpp
@@ -102,7 +102,7 @@ void common_run(const vector<string>& urls, const stats_config& cfg_stats, const
 		// make_unique is not supported by GCC 4.8, only starting from GCC 4.9 :(
 		try {
 			stats = unique_ptr<socket::stats_writer>(
-				new socket::stats_writer(cfg_stats.stats_file, milliseconds(cfg_stats.stats_freq_ms)));
+				new socket::stats_writer(cfg_stats.stats_file, cfg_stats.stats_format, milliseconds(cfg_stats.stats_freq_ms)));
 		}
 		catch (const socket::exception& e)
 		{
@@ -145,7 +145,7 @@ void common_run(const vector<string>& urls, const stats_config& cfg_stats, const
 			}
 
 			// Closing a listener socket (if any) will not allow further connections.
-			if (close_listener)
+			if (cfg_conn.close_listener)
 				listening_sock.reset();
 
 			if (stats)
@@ -163,7 +163,7 @@ void common_run(const vector<string>& urls, const stats_config& cfg_stats, const
 		}
 	} while ((cfg_conn.reconnect || processing_pipes.size() < cfg_conn.client_conns) && !force_break);
 
-	while (processing_pipes.empty())
+	while (!processing_pipes.empty())
 	{
 		try
 		{

--- a/xtransmit/misc.hpp
+++ b/xtransmit/misc.hpp
@@ -63,8 +63,9 @@ struct stats_config
 struct conn_config
 {
 	bool        reconnect = false; // Try to reconnect broken connections.
-	int         client_conns = 1;  // SRT Caller: the number of client connections to initiate.
+	int         max_conns = 1;     // SRT Caller: the number of client connections to initiate.
 	                               // SRT Listener: the number of allowed clients to accept.
+	int         concurrent_streams = 1;   // Maximum number of concurrent streams allowed.
 	bool        close_listener = false; // Close listener after all connection have been accepted.
 };
 
@@ -90,7 +91,7 @@ inline shared_sock_t create_connection(const std::vector<UriParser>& uris)
 }
 
 
-typedef std::function<void(shared_sock_t, const std::atomic_bool&)> processing_fn_t;
+typedef std::function<void(shared_sock_t, std::function<void (int conn_id)> const & on_done, const std::atomic_bool&)> processing_fn_t;
 
 /// @brief Creates stats writer if needed, establishes a connection, and runs `processing_fn`.
 /// @param urls a list of URLs to to establish a connection

--- a/xtransmit/misc.hpp
+++ b/xtransmit/misc.hpp
@@ -52,12 +52,20 @@ inline std::string print_timestamp_now()
 #endif // HAS_PUT_TIME
 
 
-
 struct stats_config
 {
 	int         stats_freq_ms = 0;
 	std::string stats_file;
 	std::string stats_format = "csv";
+};
+
+/// Connection establishment config
+struct conn_config
+{
+	bool        reconnect = false; // Try to reconnect broken connections.
+	int         client_conns = 1;  // SRT Caller: the number of client connections to initiate.
+	                               // SRT Listener: the number of allowed clients to accept.
+	bool        close_listener = false; // Close listener after all connection have been accepted.
 };
 
 
@@ -86,15 +94,13 @@ typedef std::function<void(shared_sock_t, const std::atomic_bool&)> processing_f
 
 /// @brief Creates stats writer if needed, establishes a connection, and runs `processing_fn`.
 /// @param urls a list of URLs to to establish a connection
-/// @param cfg 
-/// @param reconnect whether to reconnect after existing connection was broken
-/// @param close_listener whether to close a listener once a connection has been established
+/// @param cfg_stats 
+/// @param cfg_conn
 /// @param force_break 
-/// @param processing_fn
+/// @param processing_fn 
 void common_run(const std::vector<std::string>& urls,
-				const stats_config&             cfg,
-				bool                            reconnect,
-				bool                            close_listener,
+				const stats_config&             cfg_stats,
+				const conn_config&              cfg_conn,
 				const std::atomic_bool&         force_break,
 				processing_fn_t&                processing_fn);
 

--- a/xtransmit/misc.hpp
+++ b/xtransmit/misc.hpp
@@ -6,6 +6,9 @@
 #include <memory>
 #include <sstream>	// std::stringstream, std::stringbuf
 
+// Third party libraries
+#include "CLI/CLI.hpp"
+
 // xtransmit
 #include "socket.hpp"
 #include "netaddr_any.hpp"
@@ -68,6 +71,8 @@ struct conn_config
 	int         concurrent_streams = 1;   // Maximum number of concurrent streams allowed.
 	bool        close_listener = false; // Close listener after all connection have been accepted.
 };
+
+void apply_cli_opts(CLI::App& sc, conn_config& cfg);
 
 
 typedef std::shared_ptr<socket::isocket> shared_sock_t;

--- a/xtransmit/receive.cpp
+++ b/xtransmit/receive.cpp
@@ -176,7 +176,7 @@ void xtransmit::receive::run(const std::vector<std::string>& src_urls,
 {
 	using namespace std::placeholders;
 	processing_fn_t process_fn = std::bind(run_pipe, _1, cfg, _2);
-	common_run(src_urls, cfg, cfg.reconnect, cfg.close_listener, force_break, process_fn);
+	common_run(src_urls, cfg, cfg, force_break, process_fn);
 }
 
 CLI::App* xtransmit::receive::add_subcommand(CLI::App& app, config& cfg, std::vector<std::string>& src_urls)
@@ -191,6 +191,7 @@ CLI::App* xtransmit::receive::add_subcommand(CLI::App& app, config& cfg, std::ve
 	sc_receive->add_option("--statsfreq", cfg.stats_freq_ms, fmt::format("Output stats report frequency, ms (default {})", cfg.stats_freq_ms))
 		->transform(CLI::AsNumberWithUnit(to_ms, CLI::AsNumberWithUnit::CASE_SENSITIVE));
 	sc_receive->add_flag("--printmsg", cfg.print_notifications, "Print message to stdout");
+	sc_receive->add_option("--clients", cfg.client_conns, "Number of client connections to initiate or accept");
 	sc_receive->add_flag("--reconnect,!--no-reconnect", cfg.reconnect, "Reconnect automatically");
 	sc_receive->add_flag("--close-listener,!--no-close-listener", cfg.close_listener, "Close listener once connection is established");
 	sc_receive->add_flag("--enable-metrics", cfg.enable_metrics, "Enable checking metrics: jitter, latency, etc.");

--- a/xtransmit/receive.cpp
+++ b/xtransmit/receive.cpp
@@ -195,15 +195,13 @@ CLI::App* xtransmit::receive::add_subcommand(CLI::App& app, config& cfg, std::ve
 	sc_receive->add_option("--statsfreq", cfg.stats_freq_ms, fmt::format("Output stats report frequency, ms (default {})", cfg.stats_freq_ms))
 		->transform(CLI::AsNumberWithUnit(to_ms, CLI::AsNumberWithUnit::CASE_SENSITIVE));
 	sc_receive->add_flag("--printmsg", cfg.print_notifications, "Print message to stdout");
-	sc_receive->add_option("--maxconns", cfg.max_conns, "Maximum Number of connections to initiate or accept");
-	sc_receive->add_option("--concurrent-streams", cfg.concurrent_streams, "Maximum Number of concurrect receiving streams");
-	sc_receive->add_flag("--reconnect,!--no-reconnect", cfg.reconnect, "Reconnect automatically");
-	sc_receive->add_flag("--close-listener,!--no-close-listener", cfg.close_listener, "Close listener once connection is established");
 	sc_receive->add_flag("--enable-metrics", cfg.enable_metrics, "Enable checking metrics: jitter, latency, etc.");
 	sc_receive->add_option("--metricsfile", cfg.metrics_file, "Metrics output filename (default stdout)");
 	sc_receive->add_option("--metricsfreq", cfg.metrics_freq_ms, fmt::format("Metrics report frequency, ms (default {})", cfg.metrics_freq_ms))
 		->transform(CLI::AsNumberWithUnit(to_ms, CLI::AsNumberWithUnit::CASE_SENSITIVE));
 	sc_receive->add_flag("--twoway", cfg.send_reply, "Both send and receive data");
+
+	apply_cli_opts(*sc_receive, cfg);
 
 	return sc_receive;
 }

--- a/xtransmit/receive.hpp
+++ b/xtransmit/receive.hpp
@@ -13,12 +13,10 @@ namespace xtransmit
 namespace receive
 {
 
-struct config : stats_config
+struct config : stats_config, conn_config
 {
 	bool        print_notifications = false; // Print notifications about the messages received
 	bool        send_reply          = false;
-	bool        reconnect           = false;
-	bool        close_listener      = false;
 	bool        enable_metrics      = false;
 	unsigned    metrics_freq_ms     = 1000;
 	std::string metrics_file;

--- a/xtransmit/route.cpp
+++ b/xtransmit/route.cpp
@@ -110,7 +110,7 @@ void xtransmit::route::run(const vector<string>& src_urls, const vector<string>&
 
 		future<void> route_bkwd = cfg.bidir
 			? ::async(::launch::async, route, dst, src, cfg, "[DST->SRC]", ref(force_break))
-			: future<void>();	
+			: future<void>();
 
 		route(src, dst, cfg, "[SRC->DST]", force_break);
 

--- a/xtransmit/socket.hpp
+++ b/xtransmit/socket.hpp
@@ -23,11 +23,10 @@ class exception : public std::exception
 {
 public:
 	explicit exception(const std::string &&err)
-		: m_error_msg(std::move(err)) // note "short string optimization" (SSO)
+		: m_error_msg(err) // note "short string optimization" (SSO)
 	{
 	}
 
-public:
 	virtual const char *what() const throw() { return m_error_msg.c_str(); }
 
 private:

--- a/xtransmit/xtransmit-app.cpp
+++ b/xtransmit/xtransmit-app.cpp
@@ -123,7 +123,7 @@ int main(int argc, char** argv)
 	CLI::App app("SRT xtransmit tool. SRT library v" SRT_VERSION_STRING);
 	app.set_config("--config");
 	app.set_help_all_flag("--help-all", "Expand all help");
-	app.set_version_flag("--version", string("srt-xtransmit v0.2.0 dev.\nSRT library v") + SRT_VERSION_STRING + " clock " + srt_clock_type_str());
+	app.set_version_flag("--version", string("srt-xtransmit v0.3.0 dev.\nSRT library v") + SRT_VERSION_STRING + " clock " + srt_clock_type_str());
 
 	spdlog::set_pattern("%H:%M:%S.%f %^[%L]%$ %v");
 	app.add_flag_function(


### PR DESCRIPTION
Two new CLI options are added to `receive` and `generate` subcommand.
- `--maxconns`: specifies the maximum number of connections to initiate or accept (-1: infinite, default: 1).
- `--concurrent-streams`: specifies the maximum number of concurrent streams (default: 1)..



In the case of SRT caller, `maxconns` connections will be initiated by default from a different source UDP port to the same remote UDP port.

```shell
srt-xtransmit generate srt://127.0.0.1:4200?bind=:5200 --sendrate 5Mbps --duration 5s
    --reconnect --concurrent-streams 2 --maxconns 2

srt-xtransmit receive srt://:4200 -v --reconnect --concurrent-streams 2 --maxconns 2
```

To initiate connections from the same port bind to that port explicitly.

```shell
srt-xtransmit generate srt://127.0.0.1:4200?bind=:5200 --sendrate 5Mbps --duration 5s
    --reconnect --concurrent-streams 2 --maxconns 2
```

In the case of SRT listener up to `n` incoming connection requests will be accepted.

Each SRT connection creates a separate thread for a processing loop.
There is no way to specify different remotes yet, mainly due to the potential collision of the CLI syntax with the SRT socket group syntax.

## Example Usage

### Call from Different UDP Ports

Sender/caller (`generate`), receiver/listener (`receive`).

```shell
(receiver, accepting on UDP port 4200)
./srt-xtransmit receive srt://:4200 --enable-metrics --maxconns 6 --concurrent-streams 4

(sender, calling from different random UDP ports to a single remote UDP port 4200)
./srt-xtransmit generate srt://127.0.0.1:4200 --sendrate 1Mbps --enable-metrics --maxconns 6 --concurrent-streams 4
```

#### Call from the Same UDP Port

Sender/listener (`generate`), receiver/caller (`receive`).

```shell
(receiver, calling from the same UDP port 4201 to a single remote UDP port 4200)
./srt-xtransmit receive "srt://127.0.0.1:4200?bind=127.0.0.1:4201" --enable-metrics --maxconns 6 --concurrent-streams 4

(sender, accepting on UDP port 4200)
./srt-xtransmit generate "srt://:4200" --sendrate 1Mbps --enable-metrics --maxconns 6 --concurrent-streams 4
```

## TODO

- [x] Does not work properly with the `--reconnect` option. Client must tell the number of simultaneous connections, i.e. wait for it to finish before reconnecting.

- [x] Move metrics thread to be shared between pipes.