### PR TITLE
Adding a separate thread for metrics

### DIFF
--- a/xtransmit/receive.cpp
+++ b/xtransmit/receive.cpp
@@ -98,7 +98,7 @@ void run_pipe(shared_sock src, const config &cfg, const atomic_bool &force_break
 	vector<char> buffer(cfg.message_size);
 	metrics::validator validator;
 
-	atomic_bool metrics_stop = false;
+	atomic_bool metrics_stop(false);
 	mutex metrics_mtx;
 	future<void> metrics_th;
 	ofstream metrics_file;

--- a/xtransmit/receive.cpp
+++ b/xtransmit/receive.cpp
@@ -74,7 +74,7 @@ void metrics_writing_loop(ofstream&                   metrics_file,
 		const auto tnow = steady_clock::now();
 		if (tnow >= stat_time)
 		{
-			if (metrics_file)
+			if (metrics_file.is_open())
 			{
 				lock_guard<mutex> lck(mtx);
 				metrics_file << validator.stats_csv(false);


### PR DESCRIPTION
In certain testing scenarios a stream might get paused for at least several seconds. In that case, there would be no updates to the metrics file.
Moving metrics writing facilities to a separate thread allows independent metrics tracing.