### PR TITLE
Add integrity check metrics: MD5 checksum and packet length

### DIFF
--- a/xtransmit/metrics.cpp
+++ b/xtransmit/metrics.cpp
@@ -112,30 +112,32 @@ uint64_t read_packet_length(const vector<char>& payload)
 
 void write_packet_checksum(vector<char>& payload)
 {
-	srt::md5_state_t s;
-	srt::md5_init(&s);
+	using namespace srt;
+	md5_state_t s;
+	md5_init(&s);
 
-	md5_append(&s, (const srt::md5_byte_t*) payload.data(), (int)PKT_MD5_BYTE_OFFSET);
+	md5_append(&s, (const md5_byte_t*) payload.data(), (int)PKT_MD5_BYTE_OFFSET);
 
 	const ptrdiff_t skip = PKT_MD5_BYTE_OFFSET + PKT_MD5_BYTE_LEN;
-	md5_append(&s, (const srt::md5_byte_t*)payload.data() + skip, (int)(payload.size() - skip));
-	md5_finish(&s, (srt::md5_byte_t*) (payload.data() + PKT_MD5_BYTE_OFFSET));
+	md5_append(&s, (const md5_byte_t*)payload.data() + skip, (int)(payload.size() - skip));
+	md5_finish(&s, (md5_byte_t*) (payload.data() + PKT_MD5_BYTE_OFFSET));
 }
 
 bool validate_packet_checksum(const vector<char>& payload)
 {
-	srt::md5_state_t s;
-	srt::md5_init(&s);
+	using namespace srt;
+	md5_state_t s;
+	md5_init(&s);
 
-	md5_append(&s, (const srt::md5_byte_t*)payload.data(), (int)PKT_MD5_BYTE_OFFSET);
+	md5_append(&s, (const md5_byte_t*)payload.data(), (int)PKT_MD5_BYTE_OFFSET);
 
 	const ptrdiff_t skip = PKT_MD5_BYTE_OFFSET + PKT_MD5_BYTE_LEN;
-	md5_append(&s, (const srt::md5_byte_t*)payload.data() + skip, (int)(payload.size() - skip));
+	md5_append(&s, (const md5_byte_t*)payload.data() + skip, (int)(payload.size() - skip));
 
-	std::array<srt::md5_byte_t, PKT_MD5_BYTE_LEN> result;
+	array<md5_byte_t, PKT_MD5_BYTE_LEN> result;
 	md5_finish(&s, result.data());
 
-	const srt::md5_byte_t* ptr = (srt::md5_byte_t*) (payload.data() + PKT_MD5_BYTE_OFFSET);
+	const md5_byte_t* ptr = (md5_byte_t*) (payload.data() + PKT_MD5_BYTE_OFFSET);
 	const int cmpres = std::memcmp(ptr, result.data(), result.size());
 
 	return cmpres == 0;

--- a/xtransmit/metrics_integrity.hpp
+++ b/xtransmit/metrics_integrity.hpp
@@ -28,7 +28,7 @@ public:
 	{
 		if (!is_correct_length)
 		{
-			++m_stats.pkts_wrong_checksum;
+			++m_stats.pkts_wrong_len;
 			spdlog::warn("[METRICS] Incorrect length of packet seqno {}.", pkt_seqno);
 		}
 

--- a/xtransmit/metrics_integrity.hpp
+++ b/xtransmit/metrics_integrity.hpp
@@ -1,0 +1,50 @@
+#pragma once
+#include <algorithm> // std::max
+#include <chrono>
+
+namespace xtransmit
+{
+namespace metrics
+{
+
+class integrity
+{
+public:
+	integrity() {}
+
+public:
+	struct stats
+	{
+		uint64_t pkts_wrong_len = 0;
+		uint64_t pkts_wrong_checksum = 0;
+	};
+
+public:
+	/// Submit new sample for integrity update.
+	/// @param [in] pkt_seqno newly arrived packet sequence number
+	/// @param [in] is_correct_length true if the packet length is correct
+	/// @param [in] is_valid_checksum true if the checksum is correct
+	void submit_sample(const uint64_t pkt_seqno, const bool is_correct_length, const bool is_valid_checksum)
+	{
+		if (!is_correct_length)
+		{
+			++m_stats.pkts_wrong_checksum;
+			spdlog::warn("[METRICS] Incorrect length of packet seqno {}.", pkt_seqno);
+		}
+
+		if (!is_valid_checksum)
+		{
+			++m_stats.pkts_wrong_checksum;
+			spdlog::warn("[METRICS] Incorrect checksum of packet seqno {}.", pkt_seqno);
+		}
+	}
+
+	stats get_stats() const { return m_stats; }
+
+private:
+	stats m_stats;
+};
+
+
+} // namespace metrics
+} // namespace xtransmit

--- a/xtransmit/metrics_reorder.hpp
+++ b/xtransmit/metrics_reorder.hpp
@@ -53,6 +53,13 @@ public:
 		}
 	}
 
+	/// @brief Increment the number of packets received, and don't touch other metrics.
+	/// Should be used when a packet received is corrupted.
+	void inc_pkts_received()
+	{
+		++m_stats.pkts_processed;
+	}
+
 	/// Get curent jitter value.
 	uint64_t pkts_lost() const { return m_stats.pkts_lost; }
 

--- a/xtransmit/metrics_reorder.hpp
+++ b/xtransmit/metrics_reorder.hpp
@@ -10,7 +10,7 @@ namespace metrics
 class reorder
 {
 public:
-    reorder() {}
+	reorder() {}
 
 public:
 	struct stats
@@ -25,7 +25,7 @@ public:
 public:
 	/// Submit new sample for reorder update.
 	/// @param [in] pkt_seqno newly arrived packet sequence number
-    void submit_sample(const uint64_t pkt_seqno)
+	void submit_sample(const uint64_t pkt_seqno)
 	{
 		++m_stats.pkts_processed;
 
@@ -54,7 +54,7 @@ public:
 	}
 
 	/// Get curent jitter value.
-    uint64_t pkts_lost() const { return m_stats.pkts_lost; }
+	uint64_t pkts_lost() const { return m_stats.pkts_lost; }
 
 	stats get_stats() const { return m_stats; }
 


### PR DESCRIPTION
The metrics payload adds two more fields: MD5 checksum and packet length.
Those fields can be used by the receiver to validate that the payload was not altered and that the length of the payload is correct.

The updated format of a generated packet:
```
///     0         1         2         3         4         5         6
///     0 2 4 6 8 0 2 4 6 8 0 2 4 6 8 0 2 4 6 8 0 2 4 6 8 0 2 4 6 8 0 2 4
///    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
///  0 |                      Packet Sequence Number                   |
///    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
///  8 |                      System Clock Timestamp                   |
///    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
/// 16 |                     Monotonic Clock Timestamp                 |
///    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
/// 32 |                              Length                           |
///    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
/// 40 |                           MD5 Checksum                        |
///    |                                                               |
///    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
/// 56 |                         Remaining payload                     |
///
///    |<-------------------------- 64 bits -------------------------->|
```

### Note

Packet length might be redundant given the checksum is there. But it might be also useful when only a couple of bytes in a packet are corrupted.