### PR TITLE
Fixed crash if wrong URL is given

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,8 @@
 # Build results
 _build*/
 build*/
+.venv/
+venv/
 [Dd]ebug/
 [Dd]ebugPublic/
 [Rr]elease/

--- a/xtransmit/misc.cpp
+++ b/xtransmit/misc.cpp
@@ -137,6 +137,12 @@ void common_run(const vector<string>& urls, const stats_config& cfg, bool reconn
 			// The scope of `conn` closes it unless stats_writer holds a pointer.
 			shared_sock_t conn = create_connection(parsed_urls, listening_sock);
 
+			if (!conn)
+			{
+				spdlog::error(LOG_SC_CONN "Failed to create a connection to '{}'.", urls[0]);
+				return;
+			}
+
 			// Closing a listener socket (if any) will not allow further connections.
 			if (!reconnect)
 				listening_sock.reset();


### PR DESCRIPTION
For example `generate help`. In this case `help` is recognized as a URL, no socket is created, and further processing has to stop here.