### PR TITLE
Show SRT config if connection is established

### DIFF
--- a/xtransmit/srt_socket.hpp
+++ b/xtransmit/srt_socket.hpp
@@ -68,6 +68,7 @@ private:
 	int  configure_pre(SRTSOCKET sock);
 	int  configure_post(SRTSOCKET sock);
 	void handle_hosts();
+	void print_negotiated_config(SRTSOCKET) const;
 
 public:
 	std::future<shared_srt> async_read(std::vector<char>& buffer);

--- a/xtransmit/srt_socket.hpp
+++ b/xtransmit/srt_socket.hpp
@@ -68,7 +68,7 @@ private:
 	int  configure_pre(SRTSOCKET sock);
 	int  configure_post(SRTSOCKET sock);
 	void handle_hosts();
-	void print_negotiated_config(SRTSOCKET) const;
+	std::string print_negotiated_config(SRTSOCKET) const;
 
 public:
 	std::future<shared_srt> async_read(std::vector<char>& buffer);


### PR DESCRIPTION
```shell
(listener)
15:44:03 [I] SOCKET::SRT 0x2EAACC42 (srt://:4200) Accepted connection 0x2EAACC41. KM state SECURED (RCV SECURED, SND SECURED).

(caller)
15:44:03 [I] SOCKET::SRT 0x25F520AF ASYNC Connected to srt://127.0.0.1:4200. KM state SECURED (RCV SECURED, SND SECURED).
```