### PR TITLE
Use the grouptype URI opt to create a single-member group.

### DIFF
--- a/xtransmit/misc.cpp
+++ b/xtransmit/misc.cpp
@@ -21,13 +21,7 @@ shared_sock_t create_connection(const vector<UriParser>& parsed_urls, shared_soc
 		throw socket::exception("No URL was provided");
 	}
 
-	// if (parsed_urls[0].count("groupconnect"))
-	// {
-
-	// }
-	// SRTO_GROUPCONNECT
-
-	if (parsed_urls.size() > 1)
+	if (parsed_urls.size() > 1 || parsed_urls[0].parameters().count("grouptype"))
 	{
 #if ENABLE_BONDING
 		// Group SRT connection


### PR DESCRIPTION
Example CLI:
```shell
srt-xtransmit receive srt://192.168.0.1:4200?grouptype=broadcast --enable-metrics -v
```