### PR TITLE
SC receive and send: Made the 'reconnect' option 'true' by default

### DIFF
--- a/xtransmit/generate.hpp
+++ b/xtransmit/generate.hpp
@@ -20,7 +20,7 @@ struct config : public stats_config
 	int         duration       = 0;
 	int         message_size   = 1316; ////8 * 1024 * 1024;
 	bool        two_way        = false;
-	bool        reconnect      = false;
+	bool        reconnect      = true;
 	bool        enable_metrics = false;
 	bool        spin_wait      = false;
 	std::string playback_csv;

--- a/xtransmit/receive.hpp
+++ b/xtransmit/receive.hpp
@@ -17,7 +17,7 @@ struct config : stats_config
 {
 	bool        print_notifications = false; // Print notifications about the messages received
 	bool        send_reply          = false;
-	bool        reconnect           = false;
+	bool        reconnect           = true;
 	bool        enable_metrics      = false;
 	unsigned    metrics_freq_ms     = 1000;
 	std::string metrics_file;


### PR DESCRIPTION
The reconnect=true is needed for group connections to connect all the members. To reduce confusion and the rate of command-line errors  it is now enabled by the default.