### PR TITLE
Show group member SRC and DST address on reconnection.

### DIFF
--- a/xtransmit/srt_socket_group.cpp
+++ b/xtransmit/srt_socket_group.cpp
@@ -479,8 +479,9 @@ void socket::srt_group::on_connect_callback(SRTSOCKET sock, int error, const soc
 		return;
 	}
 
-	spdlog::warn(LOG_SRT_GROUP "@{} Member socket @{} (token {}) connection error: ({}) {}.", m_bind_socket, sock, token, error,
-		srt_strerror(error, 0));
+	
+
+	SRT_SOCKGROUPCONFIG* member = nullptr;
 
 	bool reconn_scheduled = false;
 	for (auto target : m_targets)
@@ -488,20 +489,32 @@ void socket::srt_group::on_connect_callback(SRTSOCKET sock, int error, const soc
 		if (target.token != token)
 			continue;
 
-		auto connfn = [](SRTSOCKET group, SRT_SOCKGROUPCONFIG target) {
-			spdlog::trace(LOG_SRT_GROUP "@{}: Reconnecting member socket (token {})", group, target.token);
-			const int st = srt_connect_group(group, &target, 1);
-			if (st == SRT_ERROR)
-				spdlog::warn(LOG_SRT_GROUP "@{}: Member reconnection failed (token {})", group, target.token);
-		};
-
-		spdlog::trace(LOG_SRT_GROUP "@{}: Scheduling member reconnection (token {})", m_bind_socket, token);
-		reconn_scheduled = true;
-		m_scheduler.schedule_in(std::chrono::seconds(1), connfn, m_bind_socket, target);
+		member = &target;
+		break;
 	}
 
-	if (!reconn_scheduled)
+	auto connfn = [](SRTSOCKET group, SRT_SOCKGROUPCONFIG target) {
+		spdlog::trace(LOG_SRT_GROUP "@{}: Reconnecting member socket (token {})", group, target.token);
+		const int st = srt_connect_group(group, &target, 1);
+		if (st == SRT_ERROR)
+			spdlog::warn(LOG_SRT_GROUP "@{}: Member reconnection failed (token {})", group, target.token);
+		};
+
+	if (member)
+	{
+		spdlog::warn(LOG_SRT_GROUP "@{} Member socket @{} ({}->{}) connection error: ({}) {}.", m_bind_socket, sock,
+			netaddr_any(member->srcaddr).str(), netaddr_any(member->peeraddr).str(), error,
+			srt_strerror(error, 0));
+
+		spdlog::trace(LOG_SRT_GROUP "@{}: Scheduling member reconnection ({} -> {})", m_bind_socket,
+			netaddr_any(member->srcaddr).str(), netaddr_any(member->peeraddr).str());
+		reconn_scheduled = true;
+		m_scheduler.schedule_in(std::chrono::seconds(1), connfn, m_bind_socket, *member);
+	}
+	else
+	{
 		spdlog::warn(LOG_SRT_GROUP "@{}: Could not schedule member reconnection (token {})", m_bind_socket, token);
+	}
 
 	return;
 }


### PR DESCRIPTION
Show this:
```
16:37:28.065464 [W] SOCKET::SRT_GROUP @1672042680 Member socket @598300852 (0.0.0.0:0->127.0.0.1:5200) connection error: (1001) Connection setup failure: connection timed out.
16:37:28.066640 [T] SOCKET::SRT_GROUP @1672042680: Scheduling member reconnection (0.0.0.0:0 -> 127.0.0.1:5200)
```

instead of this:
```
16:31:48.336160 [T] SOCKET::SRT_GROUP @1762087632: Scheduling member reconnection (token 2)
16:31:48.606523 [I] GENERATE Sending at 997 kbps
16:31:49.344063 [T] SOCKET::SRT_GROUP @1762087632: Reconnecting member socket (token 2)
16:31:49.608895 [I] GENERATE Sending at 998 kbps
```