### PR TITLE
GCC warning about copying 26 bytes from 16 byte structure.

### DIFF
--- a/xtransmit/srt_socket_group.cpp
+++ b/xtransmit/srt_socket_group.cpp
@@ -436,10 +436,10 @@ int socket::srt_group::listen_callback_fn(void* opaq, SRTSOCKET sock, int hsvers
 
 	netaddr_any sa(peeraddr);
 
-	sockaddr host_sa = {};
-	int host_sa_len = sizeof host_sa;
-	srt_getsockname(sock, &host_sa, &host_sa_len);
-	netaddr_any host(&host_sa, host_sa_len);
+	netaddr_any host_sa;
+	int host_sa_len = host_sa.storage_size();
+	srt_getsockname(sock, host_sa.get(), &host_sa_len);
+	netaddr_any host(host_sa.get(), host_sa_len);
 	spdlog::trace(LOG_SRT_GROUP "Accepted member socket @{}, host IP {}, remote IP {}", sock, host.str(), sa.str());
 
 	// TODO: this group may no longer exist. Use some global array to track valid groups.


### PR DESCRIPTION
GCC 12.3.0:

```shell
[ 79%] Building CXX object xtransmit/CMakeFiles/srt-xtransmit.dir/srt_socket_group.cpp.o
In file included from /usr/include/string.h:535,
                 from /usr/include/c++/12/cstring:42,
                 from /srt-xtransmit/submodule/spdlog/include/spdlog/fmt/bundled/core.h:12,
                 from /srt-xtransmit/submodule/spdlog/include/spdlog/fmt/fmt.h:20,
                 from /srt-xtransmit/submodule/spdlog/include/spdlog/common.h:36,
                 from /srt-xtransmit/submodule/spdlog/include/spdlog/spdlog.h:12,
                 from /srt-xtransmit/xtransmit/srt_socket_group.cpp:8:
In function ‘void* memcpy(void*, const void*, size_t)’,
    inlined from ‘void xtransmit::netaddr_any::set(const sockaddr*)’ at /srt-xtransmit/xtransmit/netaddr_any.hpp:153:19,
    inlined from ‘xtransmit::netaddr_any::netaddr_any(const sockaddr*, len_t)’ at /srt-xtransmit/xtransmit/netaddr_any.hpp:136:16,
    inlined from ‘static int xtransmit::socket::srt_group::listen_callback_fn(void*, SRTSOCKET, int, const sockaddr*, const char*)’ at /srt-xtransmit/xtransmit/srt_socket_group.cpp:442:40:
/usr/include/x86_64-linux-gnu/bits/string_fortified.h:29:33: warning: ‘void* __builtin_memcpy(void*, const void*, long unsigned int)’ reading 28 bytes from a region of size 16 [-Wstringop-overread]
   29 |   return __builtin___memcpy_chk (__dest, __src, __len,
      |          ~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~
   30 |                                  __glibc_objsize0 (__dest));
      |                                  ~~~~~~~~~~~~~~~~~~~~~~~~~~
/srt-xtransmit/xtransmit/srt_socket_group.cpp: In static member function ‘static int xtransmit::socket::srt_group::listen_callback_fn(void*, SRTSOCKET, int, const sockaddr*, const char*)’:
/srt-xtransmit/xtransmit/srt_socket_group.cpp:439:18: note: source object ‘host_sa’ of size 16
  439 |         sockaddr host_sa = {};
      |                  ^~~~~~~
[ 80%] Linking CXX executable ../bin/srt-xtransmit
```