### PR TITLE
Fixed printing StreamID of a connected socket.

### DIFF
--- a/xtransmit/srt_socket.cpp
+++ b/xtransmit/srt_socket.cpp
@@ -381,15 +381,16 @@ std::string socket::srt::print_negotiated_config(SRTSOCKET sock)
 	const string crypto_mode_str = "";
 #endif
 #undef VAL_AND_STR
-	
+
 	// Template lambdas are only available since C++20, have to duplicate the code.
 	std::string streamid(512, '\0');
-	int         streamid_len = (int) streamid.size();
+	auto        streamid_len = (int)streamid.size();
 	if (srt_getsockflag(sock, SRTO_STREAMID, (void*)streamid.data(), &streamid_len) != SRT_SUCCESS)
 	{
 		spdlog::error(LOG_SOCK_SRT "Failed to get sockopt SRTO_STREAMID.");
 		streamid_len = 0;
 	}
+	streamid.resize(streamid_len);
 
 	return fmt::format("TSBPD {}. KM state {} (RCV {}, SND {}). PB key length: {}. Cryptomode {}. Stream ID: {}",
 					   latency_str,


### PR DESCRIPTION
Was outputting all the trailing NUL characters of a buffer.

Now the following output when saved to a text file:

<img width="707" alt="image" src="https://github.com/user-attachments/assets/e5c784bd-c276-4c1f-a928-89789c16707b">
