### PR TITLE
Assign names to application threads

### DIFF
--- a/xtransmit/generate.cpp
+++ b/xtransmit/generate.cpp
@@ -17,6 +17,7 @@
 #include "generate.hpp"
 #include "pacer.hpp"
 #include "metrics.hpp"
+#include "xtr_defs.hpp"
 
 // OpenSRT
 #include "apputil.hpp"
@@ -34,6 +35,7 @@ using shared_sock = std::shared_ptr<socket::isocket>;
 
 void run_pipe(shared_sock dst, const config& cfg, std::function<void(int conn_id)> const& on_done, const atomic_bool& force_break)
 {
+	XTR_THREADNAME(std::string("XTR:Gen"));
 	vector<char> message_to_send(cfg.message_size);
 	iota(message_to_send.begin(), message_to_send.end(), (char)0);
 

--- a/xtransmit/metrics_writer.cpp
+++ b/xtransmit/metrics_writer.cpp
@@ -1,6 +1,7 @@
 #include <thread>
 #include <mutex>
 #include "metrics_writer.hpp"
+#include "xtr_defs.hpp"
 
 // submodules
 #include "spdlog/spdlog.h"
@@ -149,6 +150,7 @@ future<void> metrics_writer::launch()
 		}
 	};
 
+	XTR_THREADNAME(std::string("XTR:Metrics"));
 	return async(
 		::launch::async, metrics_func, ref(m_validators), ref(m_file), m_interval, ref(m_lock), ref(m_stop_token));
 }

--- a/xtransmit/misc.cpp
+++ b/xtransmit/misc.cpp
@@ -3,7 +3,7 @@
 #include "misc.hpp"
 #include "socket_stats.hpp"
 #include "srt_socket_group.hpp"
-
+#include "xtr_defs.hpp"
 // submodules
 #include "spdlog/spdlog.h"
 
@@ -177,6 +177,7 @@ private:
 void common_run(const vector<string>& urls, const stats_config& cfg_stats, const conn_config& cfg_conn,
 	const atomic_bool& break_token, processing_fn_t& processing_fn)
 {
+	//XTR_THREADNAME(std::string("XTR:ConnMngmt"));
 	if (urls.empty())
 	{
 		spdlog::error(LOG_SC_CONN "URL was not provided");

--- a/xtransmit/route.cpp
+++ b/xtransmit/route.cpp
@@ -20,6 +20,7 @@
 // OpenSRT
 #include "apputil.hpp"
 #include "uriparser.hpp"
+#include "xtr_defs.hpp"
 
 using namespace std;
 using namespace xtransmit;
@@ -39,6 +40,7 @@ namespace route
 	void route(shared_sock src, shared_sock dst,
 		const config& cfg, const string&& desc, const atomic_bool& force_break)
 	{
+		XTR_THREADNAME(std::string("XTR:Route"));
 		vector<char> buffer(cfg.message_size);
 
 		socket::isocket& sock_src = *src.get();

--- a/xtransmit/socket_stats.cpp
+++ b/xtransmit/socket_stats.cpp
@@ -1,5 +1,6 @@
 #include <thread>
 #include "socket_stats.hpp"
+#include "xtr_defs.hpp"
 
 // submodules
 #include "spdlog/spdlog.h"
@@ -78,7 +79,7 @@ future<void> xtransmit::socket::stats_writer::launch()
 	auto print_stats = [](map<SOCKET, shared_sock>& sock_vector,
 		ofstream& out,
 		mutex& stats_lock,
-		string format,
+		const string& format,
 		bool print_header)
 	{
 #ifdef ENABLE_CXX17
@@ -94,7 +95,7 @@ future<void> xtransmit::socket::stats_writer::launch()
 				continue;
 			}
 
-			auto* s = it.second.get();
+			const auto* s = it.second.get();
 
 			try
 			{
@@ -130,7 +131,7 @@ future<void> xtransmit::socket::stats_writer::launch()
 
 	auto stats_func = [&print_stats](map<SOCKET, shared_sock>& sock_vector,
 						 ofstream&            out,
-						 string&              format,
+						 const string&        format,
 						 const milliseconds   interval,
 						 mutex&               stats_lock,
 						 const atomic_bool&   stop_stats) {
@@ -145,5 +146,6 @@ future<void> xtransmit::socket::stats_writer::launch()
 		}
 	};
 
+	XTR_THREADNAME(std::string("XTR:Stats"));
 	return async(::launch::async, stats_func, ref(m_sock), ref(m_logfile), ref(m_format), m_interval, ref(m_lock), ref(m_stop));
 }

--- a/xtransmit/xtr_defs.hpp
+++ b/xtransmit/xtr_defs.hpp
@@ -1,0 +1,26 @@
+#pragma once
+#include "srt.h"
+
+#if SRT_VERSION_VALUE >= SRT_MAKE_VERSION(1, 5, 0)
+#include "threadname.h" // srt::ThreadName
+#define XTR_THREADNAME(name) srt::ThreadName tn(name);
+#else
+#define XTR_THREADNAME(name)
+#endif
+
+namespace xtransmit
+{
+namespace details
+{
+template <typename T, typename... Args>
+std::unique_ptr<T> make_unique(Args&&... args)
+{
+#if defined(_MSC_VER) || __cplusplus >= 201402L // C++14 and beyond
+	return std::make_unique<T>(std::forward<Args>(args)...);
+#else
+	static_assert(!std::is_array<T>::value, "arrays are not supported");
+	return std::unique_ptr<T>(new T(std::forward<Args>(args)...));
+#endif
+}
+} // namespace details
+} // namespace xtransmit


### PR DESCRIPTION
Thread names:
- XTR:Gen
- XTR:Metrics
- XTR:Stats
- XTR:Rcv
- XTR:Route

Example `top` output:

```
  PID USER      PR  NI  VIRT  RES  SHR S %CPU %MEM    TIME+  COMMAND
21620 admin     20   0  316m 7096 5336 S   10  0.5   0:01.81 SRT:RcvQ:w1
21626 admin     20   0  316m 7096 5336 S    8  0.5   0:01.30 XTR:Rcv
21627 admin     20   0  316m 7096 5336 S    8  0.5   0:01.31 SRT:TsbPd 
21617 admin     20   0  316m 7096 5336 S    0  0.5   0:00.01 srt-xtransmit 
21618 admin     20   0  316m 7096 5336 S    0  0.5   0:00.00 SRT:GC 
21619 admin     20   0  316m 7096 5336 S    0  0.5   0:00.00 SRT:SndQ:w1 
21625 admin     20   0  316m 7096 5336 S    0  0.5   0:00.00 XTR:Stats   
```