### PR TITLE
Improve generator performance by bypassing std::vector checks.

### DIFF
--- a/xtransmit/metrics.hpp
+++ b/xtransmit/metrics.hpp
@@ -50,7 +50,8 @@ namespace metrics
 		inline void generate_payload(vector<char>& payload)
 		{
 			const int seqno = m_seqno++;
-			iota(payload.begin(), payload.end(), static_cast<char>(seqno));
+			// Using data() instead of begin() significantly improves performance. See #104.
+			iota(payload.data(), payload.data() + payload.size(), static_cast<char>(seqno));
 			if (!m_enable_metrics)
 				return;
 


### PR DESCRIPTION
25 Mbps sending on MX4.

Before:

![image](https://github.com/user-attachments/assets/fca86cc5-c9ac-407c-b3d1-e88d5ec0423c)

After:

![image](https://github.com/user-attachments/assets/69df8c7a-4f06-45d4-96f4-aa196bd99a5a)
