### PR TITLE
Receive: rebase dump-to-file and harden file dumping

### DIFF
--- a/xtransmit/receive.hpp
+++ b/xtransmit/receive.hpp
@@ -20,6 +20,8 @@ struct config : stats_config, conn_config
 	bool        enable_metrics      = false;
 	unsigned    metrics_freq_ms     = 1000;
 	std::string metrics_file;
+	std::string dump_to_file;
+	std::string dump_timestamps_to_file;
 	int         max_connections = 1; // Maximum number of connections on a socket
 	int         message_size    = 1316;
 };


### PR DESCRIPTION
## Summary
- Rebased dump-to-file work on top of latest `master`
- Removed unused `--dump-timestamps-to-file` option for now
- Made dump output connection-specific when `max_connections > 1` by inserting socket ID before file extension
- Fixed cleanup path when dump file open fails (metrics validator removal + `on_done` callback)
- Added explicit write-failure handling for dump output

## Notes
- Dump file naming now uses `<name>.<socket_id><ext>` (for example: `capture.1234.ts`) when multiple connections are allowed.

## Testing
- Environment build configure is currently blocked by missing OpenSSL dev libraries (`OPENSSL_ROOT_DIR` / OpenSSL include+libs).